### PR TITLE
Refactor and Enhance Dispatcher: Worker Management, pg_notify Locking, Error Handling, and More

### DIFF
--- a/dispatcher/control.py
+++ b/dispatcher/control.py
@@ -59,7 +59,7 @@ class Control:
                 ret.append(json.loads(payload))
         return ret
 
-    def get_send_message(self, command: str, reply_to: Optional[str] = None, send_data: Optional[dict] = None) -> str:
+    def create_message(self, command: str, reply_to: Optional[str] = None, send_data: Optional[dict] = None) -> str:
         to_send: dict[str, Union[dict, str]] = {'control': command}
         if reply_to:
             to_send['reply_to'] = reply_to
@@ -70,7 +70,7 @@ class Control:
     async def acontrol_with_reply(self, command: str, expected_replies: int = 1, timeout: int = 1, data: Optional[dict] = None) -> list[dict]:
         reply_queue = Control.generate_reply_queue_name()
         broker = get_broker(self.broker_name, self.broker_config, channels=[reply_queue])
-        send_message = self.get_send_message(command=command, reply_to=reply_queue, send_data=data)
+        send_message = self.create_message(command=command, reply_to=reply_queue, send_data=data)
 
         control_callbacks = BrokerCallbacks(broker=broker, queuename=self.queuename, send_message=send_message, expected_replies=expected_replies)
 
@@ -87,14 +87,14 @@ class Control:
 
     async def acontrol(self, command: str, data: Optional[dict] = None) -> None:
         broker = get_broker(self.broker_name, self.broker_config, channels=[])
-        send_message = self.get_send_message(command=command, send_data=data)
+        send_message = self.create_message(command=command, send_data=data)
         await broker.apublish_message(message=send_message)
 
     def control_with_reply(self, command: str, expected_replies: int = 1, timeout: float = 1.0, data: Optional[dict] = None) -> list[dict]:
         logger.info('control-and-reply {} to {}'.format(command, self.queuename))
         start = time.time()
         reply_queue = Control.generate_reply_queue_name()
-        send_message = self.get_send_message(command=command, reply_to=reply_queue, send_data=data)
+        send_message = self.create_message(command=command, reply_to=reply_queue, send_data=data)
 
         broker = get_broker(self.broker_name, self.broker_config, channels=[reply_queue])
 
@@ -112,5 +112,5 @@ class Control:
     def control(self, command: str, data: Optional[dict] = None) -> None:
         "Send message in fire-and-forget mode, as synchronous code. Only for no-reply control."
         broker = get_broker(self.broker_name, self.broker_config)
-        send_message = self.get_send_message(command=command, send_data=data)
+        send_message = self.create_message(command=command, send_data=data)
         broker.publish_message(channel=self.queuename, message=send_message)

--- a/dispatcher/control.py
+++ b/dispatcher/control.py
@@ -96,7 +96,7 @@ class Control:
             await broker.aclose()
 
     def control_with_reply(self, command: str, expected_replies: int = 1, timeout: float = 1.0, data: Optional[dict] = None) -> list[dict]:
-        logger.info('control-and-reply {} to {}'.format(command, self.queuename))
+        logger.info(f'control-and-reply {command} to {self.queuename}')
         start = time.time()
         reply_queue = Control.generate_reply_queue_name()
         send_message = self.create_message(command=command, reply_to=reply_queue, send_data=data)

--- a/dispatcher/protocols.py
+++ b/dispatcher/protocols.py
@@ -3,6 +3,13 @@ from typing import Any, AsyncGenerator, Callable, Coroutine, Iterable, Iterator,
 
 
 class Broker(Protocol):
+    """
+    Describes a messaging broker interface.
+
+    This interface abstracts functionality for sending and receiving messages,
+    both asynchronously and synchronously, and for managing connection lifecycles.
+    """
+
     async def aprocess_notify(
         self, connected_callback: Optional[Optional[Callable[[], Coroutine[Any, Any, None]]]] = None
     ) -> AsyncGenerator[tuple[str, str], None]:
@@ -35,10 +42,23 @@ class Broker(Protocol):
 
 
 class ProducerEvents(Protocol):
+    """
+    Describes an events container for producers.
+
+    Typically provides a signal (like a ready event) to indicate producer readiness.
+    """
+
     ready_event: asyncio.Event
 
 
 class Producer(Protocol):
+    """
+    Describes a task producer interface.
+
+    This interface encapsulates behavior for starting task production,
+    managing its lifecycle, and tracking asynchronous operations.
+    """
+
     events: ProducerEvents
 
     async def start_producing(self, dispatcher: 'DispatcherMain') -> None:
@@ -55,6 +75,13 @@ class Producer(Protocol):
 
 
 class PoolWorker(Protocol):
+    """
+    Describes an individual worker in a task pool.
+
+    It covers the properties and behaviors needed to track a worker’s execution state
+    and control its task processing lifecycle.
+    """
+
     current_task: Optional[dict]
     worker_id: int
 
@@ -70,18 +97,37 @@ class PoolWorker(Protocol):
 
 
 class Queuer(Protocol):
+    """
+    Describes an interface for managing pending tasks.
+
+    It provides a way to iterate over and modify tasks awaiting assignment.
+    """
+
     def __iter__(self) -> Iterator[dict]: ...
 
     def remove_task(self, message: dict) -> None: ...
 
 
 class Blocker(Protocol):
+    """
+    Describes an interface for handling tasks that are temporarily deferred.
+
+    It offers a mechanism to view and manage tasks that cannot run immediately.
+    """
+
     def __iter__(self) -> Iterator[dict]: ...
 
     def remove_task(self, message: dict) -> None: ...
 
 
 class WorkerData(Protocol):
+    """
+    Describes an interface for managing a collection of workers.
+
+    It abstracts how worker instances are iterated over and retrieved,
+    and it provides a lock for safe concurrent updates.
+    """
+
     management_lock: asyncio.Lock
 
     def __iter__(self) -> Iterator[PoolWorker]: ...
@@ -90,6 +136,13 @@ class WorkerData(Protocol):
 
 
 class WorkerPool(Protocol):
+    """
+    Describes an interface for a pool managing task workers.
+
+    It includes core functionality for starting the pool, dispatching tasks,
+    and shutting down the pool in a controlled manner.
+    """
+
     workers: WorkerData
     queuer: Queuer
     blocker: Blocker
@@ -106,6 +159,14 @@ class WorkerPool(Protocol):
 
 
 class DispatcherMain(Protocol):
+    """
+    Describes the primary dispatcher interface.
+
+    This interface defines the contract for the overall task dispatching service,
+    including coordinating task processing, managing the worker pool, and
+    handling delayed or control messages.
+    """
+
     pool: WorkerPool
     delayed_messages: set
 

--- a/dispatcher/service/pool.py
+++ b/dispatcher/service/pool.py
@@ -317,14 +317,22 @@ class WorkerPool(WorkerPoolProtocol):
     async def manage_old_workers(self) -> None:
         """Clear internal memory of workers whose process has exited, and assures processes are gone
 
+        This method takes a snapshot of the current workers under lock,
+        processes them outside the lock (including awaiting worker stops),
+        and then re-acquires the lock to remove workers marked for deletion.
+
         happy path:
         The scale_workers method notifies a worker they need to exit
         The read_results_task will mark the worker status to exited
         This method will see the updated status, join the process, and remove it from self.workers
         """
+        # Phase 1: Get a consistent snapshot of workers.
+        async with self.workers.management_lock:
+            current_workers = list(self.workers)
+
         remove_ids = []
-        for worker in self.workers:
-            # Check for workers that died unexpectedly
+        for worker in current_workers:
+            # Check if the worker has died unexpectedly.
             if worker.status not in ['retired', 'error', 'exited', 'initialized', 'spawned'] and not worker.process.is_alive():
                 logger.error(f'Worker {worker.worker_id} pid={worker.process.pid} has died unexpectedly, status was {worker.status}')
 
@@ -332,8 +340,7 @@ class WorkerPool(WorkerPoolProtocol):
                     uuid = worker.current_task.get('uuid', '<unknown>')
                     logger.error(f'Task (uuid={uuid}) was running on worker {worker.worker_id} but the worker died unexpectedly')
                     self.canceled_count += 1
-                    worker.is_active_cancel = False  # Ensure it's not processed by timeout runner
-
+                    worker.is_active_cancel = False  # Prevent further processing.
                 worker.status = 'error'
                 worker.retired_at = time.monotonic()
 
@@ -345,9 +352,9 @@ class WorkerPool(WorkerPoolProtocol):
             elif worker.status in ['retired', 'error'] and worker.retired_at and (time.monotonic() - worker.retired_at) > self.worker_removal_wait:
                 remove_ids.append(worker.worker_id)
 
-        # Remove workers from memory, done as separate loop due to locking concerns
-        for worker_id in remove_ids:
-            async with self.workers.management_lock:
+        # Phase 2: Remove workers from the collection under lock.
+        async with self.workers.management_lock:
+            for worker_id in remove_ids:
                 if worker_id in self.workers:
                     logger.debug(f'Fully removing worker id={worker_id}')
                     self.workers.remove_by_id(worker_id)

--- a/tests/unit/test_broker_callbacks.py
+++ b/tests/unit/test_broker_callbacks.py
@@ -1,0 +1,51 @@
+import json
+import logging
+import pytest
+
+from dispatcher.control import BrokerCallbacks
+from dispatcher.protocols import Broker
+
+
+# Dummy broker that yields first an invalid JSON message and then a valid one.
+class DummyBroker(Broker):
+    async def aprocess_notify(self, connected_callback=None):
+        if connected_callback:
+            await connected_callback()
+        # First yield an invalid JSON string, then a valid one.
+        yield ("reply_channel", "invalid json")
+        yield ("reply_channel", json.dumps({"result": "ok"}))
+
+    async def apublish_message(self, channel, message):
+        # No-op for testing.
+        return
+
+    async def aclose(self):
+        return
+
+    def process_notify(self, connected_callback=None, timeout: float = 5.0, max_messages: int = 1):
+        # Not used in this test.
+        yield ("reply_channel", "")
+
+    def publish_message(self, channel=None, message=None):
+        return
+
+    def close(self):
+        return
+
+
+@pytest.mark.asyncio
+async def test_listen_for_replies_with_invalid_json(caplog):
+    caplog.set_level(logging.WARNING)
+    dummy_broker = DummyBroker()
+    callbacks = BrokerCallbacks(
+        queuename="reply_channel",
+        broker=dummy_broker,
+        send_message="{}",
+        expected_replies=1
+    )
+    await callbacks.listen_for_replies()
+    # The invalid JSON should be ignored and only the valid message appended.
+    assert len(callbacks.received_replies) == 1
+    assert callbacks.received_replies[0] == {"result": "ok"}
+    # Verify that a warning was logged for the malformed message.
+    assert any("Invalid JSON" in record.message for record in caplog.records)

--- a/tests/unit/test_connection_saver.py
+++ b/tests/unit/test_connection_saver.py
@@ -1,0 +1,70 @@
+import threading
+import asyncio
+import pytest
+
+from dispatcher.brokers.pg_notify import connection_saver, async_connection_saver, connection_save
+
+# Define a dummy connection object that supports both sync and async close methods.
+class DummyConnection:
+    def __init__(self):
+        self.closed = False
+    def close(self):
+        self.closed = True
+    async def aclose(self):
+        self.close()
+
+connection_create_count = 0
+
+def dummy_create_connection(**config):
+    global connection_create_count
+    connection_create_count += 1
+    return DummyConnection()
+
+@pytest.fixture(autouse=True)
+def reset_sync(monkeypatch):
+    global connection_create_count
+    connection_create_count = 0
+    monkeypatch.setattr("dispatcher.brokers.pg_notify.create_connection", dummy_create_connection)
+    connection_save._connection = None
+
+def test_connection_saver_thread_safety():
+    results = []
+    def worker():
+        res = connection_saver(foo="bar")
+        results.append(res)
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # Ensure all threads got the same connection object.
+    assert all(r is results[0] for r in results)
+    # Ensure only one connection was created.
+    assert connection_create_count == 1
+    # Check that the connection supports close() properly.
+    results[0].close()
+    assert results[0].closed is True
+
+@pytest.mark.asyncio
+async def test_async_connection_saver_thread_safety(monkeypatch):
+    global connection_create_count
+    connection_create_count = 0
+
+    async def dummy_acreate_connection(**config):
+        global connection_create_count
+        connection_create_count += 1
+        return DummyConnection()
+
+    monkeypatch.setattr("dispatcher.brokers.pg_notify.acreate_connection", dummy_acreate_connection)
+    connection_save._async_connection = None
+
+    async def worker():
+        return await async_connection_saver(foo="bar")
+    results = await asyncio.gather(*[worker() for _ in range(10)])
+    # Ensure all tasks returned the same connection object.
+    assert all(r is results[0] for r in results)
+    # Ensure only one async connection was created.
+    assert connection_create_count == 1
+    await results[0].aclose()
+    assert results[0].closed is True

--- a/tests/unit/test_control_cleanup.py
+++ b/tests/unit/test_control_cleanup.py
@@ -1,0 +1,97 @@
+import asyncio
+import json
+import pytest
+
+from dispatcher.control import Control, BrokerCallbacks
+from dispatcher.protocols import Broker
+
+# Dummy broker implementation for testing cleanup.
+class DummyBroker(Broker):
+    def __init__(self):
+        self.aclose_called = False
+        self.close_called = False
+        self.sent_message = None
+
+    async def aprocess_notify(self, connected_callback=None):
+        if connected_callback:
+            await connected_callback()
+        # Yield one valid reply message.
+        yield ("dummy_channel", json.dumps({"result": "ok"}))
+
+    async def apublish_message(self, channel=None, message=""):
+        self.sent_message = message
+
+    async def aclose(self):
+        self.aclose_called = True
+
+    def process_notify(self, connected_callback=None, timeout: float = 5.0, max_messages: int = 1):
+        if connected_callback:
+            connected_callback()
+        # Yield one valid reply message.
+        yield ("dummy_channel", json.dumps({"result": "ok"}))
+
+    def publish_message(self, channel=None, message=""):
+        self.sent_message = message
+
+    def close(self):
+        self.close_called = True
+
+# Test for async control with reply cleanup
+@pytest.mark.asyncio
+async def test_acontrol_with_reply_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={})
+    result = await control.acontrol_with_reply(
+        command="test_command", expected_replies=1, timeout=2, data={"key": "value"}
+    )
+    assert result == [{"result": "ok"}]
+    assert dummy_broker.aclose_called is True
+
+# Test for async control (fire-and-forget) cleanup
+@pytest.mark.asyncio
+async def test_acontrol_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={})
+    await control.acontrol(command="test_command", data={"foo": "bar"})
+    # In acontrol, broker.aclose() should be called.
+    assert dummy_broker.aclose_called is True
+
+# Test for synchronous control_with_reply cleanup
+def test_control_with_reply_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={}, queue="test_queue")
+    result = control.control_with_reply(command="test_command", expected_replies=1, timeout=2, data={"foo": "bar"})
+    assert result == [{"result": "ok"}]
+    # For sync methods, broker.close() should be called.
+    assert dummy_broker.close_called is True
+
+# Test for synchronous control (fire-and-forget) cleanup
+def test_control_resource_cleanup(monkeypatch):
+    dummy_broker = DummyBroker()
+
+    def dummy_get_broker(broker_name, broker_config, channels=None):
+        return dummy_broker
+
+    monkeypatch.setattr("dispatcher.control.get_broker", dummy_get_broker)
+
+    control = Control(broker_name="dummy", broker_config={}, queue="test_queue")
+    control.control(command="test_command", data={"foo": "bar"})
+    assert dummy_broker.close_called is True

--- a/tests/unit/test_next_wakeup_runner_errors.py
+++ b/tests/unit/test_next_wakeup_runner_errors.py
@@ -1,0 +1,46 @@
+import time
+import pytest
+from dispatcher.service.next_wakeup_runner import NextWakeupRunner, HasWakeup
+
+
+# Dummy object that implements HasWakeup.
+class DummySchedule(HasWakeup):
+    def __init__(self, wakeup_time: float):
+        self._wakeup_time = wakeup_time
+
+    def next_wakeup(self) -> float:
+        return self._wakeup_time
+
+# Dummy process_object that simulates successful processing by pushing wakeup time forward.
+async def dummy_process_object(schedule: DummySchedule) -> None:
+    # Simulate processing by adding 10 seconds.
+    schedule._wakeup_time += 10
+
+# Dummy process_object that raises an exception.
+async def failing_process_object(schedule: DummySchedule) -> None:
+    raise ValueError("Processing error")
+
+@pytest.mark.asyncio
+async def test_process_wakeups_normal():
+    # Set up a dummy schedule with a wakeup time in the past.
+    past_time = time.monotonic() - 5
+    schedule = DummySchedule(past_time)
+    # Use dummy_process_object that adds 10 seconds.
+    runner = NextWakeupRunner([schedule], dummy_process_object)
+    current_time = time.monotonic()
+    next_wakeup = await runner.process_wakeups(current_time)
+    # The wakeup time should now be 10 seconds later than the original past time.
+    assert next_wakeup == schedule._wakeup_time
+    # Also, since the schedule was processed, it should not return None.
+    assert next_wakeup is not None
+
+@pytest.mark.asyncio
+async def test_process_wakeups_error_propagation():
+    # Set up a dummy schedule with a wakeup time in the past.
+    past_time = time.monotonic() - 5
+    schedule = DummySchedule(past_time)
+    # Use failing_process_object that raises an exception.
+    runner = NextWakeupRunner([schedule], failing_process_object)
+    current_time = time.monotonic()
+    with pytest.raises(ValueError, match="Processing error"):
+        await runner.process_wakeups(current_time)


### PR DESCRIPTION
Hey Alan!

I've been diving pretty deep into the dispatcher code while reviewing this PR ([#121](https://github.com/ansible/dispatcherd/pull/121/files)), and I ended up contributing a bunch of changes I thought might help us all. Since I'm still learning some of these concurrency and messaging patterns, I used this as an opportunity to explore new concepts. I tested everything as much as I could, though in a few places (like subtle race conditions) the tests weren’t quite as helpful as I’d hoped. But I’m definitely open if you want to cherry-pick only the changes you like. Here’s a rundown of what I did:

1. **manage_old_workers Two-Phase Locking (Potentially closes #124)**  
   - I refactored the worker-removal logic to avoid race conditions that can arise when iterating over `self.workers`. The old approach either did everything without a lock or held the lock for the entire operation, which risked either inconsistent snapshots or blocking other tasks for too long.  
   - The new strategy is a two-phase process. First, we quickly acquire the lock and take a snapshot of the current workers, then immediately release the lock. While we have that snapshot, we do the heavier work like `await worker.stop()`. Finally, we re-acquire the lock to remove any workers that have been marked for deletion.  
   - This avoids constantly locking the shared worker collection (which can block other methods like task dispatching), but still ensures no new references are added to workers we’re trying to remove. In practice, it makes shutdown a lot more robust while keeping concurrency overhead in check.

2. **pg_notify Changes: ConnectionSaver Thread Safety & Closed Connection Fixes**  
   - I initially introduced a `threading.Lock` in `ConnectionSaver` to ensure multiple threads don’t simultaneously create a new connection. This was important for concurrency so that only one connection is ever made at a time.  
   - While testing with `./run_demo.py`, I ran into issues where the demo sometimes tried to use a connection that had already been closed. To fix that, I added a check (`connection.closed != 0`) so that if the connection is no longer valid, we recreate it before handing it out again. That way, subsequent calls always get a live connection and the demo runs without errors.  
   - I added tests that verify we only create one connection across multiple threads, although reproducing every edge case can be tricky in a local environment. Nonetheless, this change should keep the dispatcher from hitting race conditions or attempting to reuse a closed connection.

3. **Resource Cleanup in Control Module**  
   - I noticed that when we create a new broker in `acontrol_with_reply`, `acontrol`, `control_with_reply`, and `control`, we never explicitly closed the connections. This could lead to resource leaks.  
   - I added `try/finally` blocks (or their equivalent) so that each ephemeral broker is properly `.close()`-d or `.aclose()`-d. That way, we don’t leave open connections lying around.  
   - I wrote tests to confirm that cleanup is called, but real concurrency scenarios are obviously more complicated.

4. **NextWakeupRunner Error Propagation**  
   - The method `process_wakeups` swallowed any exception from `process_object`, which made debugging tough. I wrapped it in a try/except, logged the error, and re-raised it.  
   - I also added a couple simple tests to make sure normal usage is still fine, plus a test that triggers the error path to confirm the exception is indeed propagated.

5. **Removing Redundant Lock in WorkerPool.dispatch_task**  
   - Since `Blocker` and `Queuer` either do their own synchronization or rely on the `management_lock` in a consistent way, we were double-locking in `dispatch_task`. I refactored it so we only lock for the part that actually modifies worker state (like starting a task).  
   - My hope is that this reduces lock contention without compromising correctness.

6. **ProcessProxy Context Manager & Type Hints**  
   - Implemented `__enter__` and `__exit__`, so we can manage worker processes with a `with` statement.  
   - I also added some type annotations so that any tricky usage or mypy checks (that's a bit of a hell) are a bit clearer. If a process is still alive on exit, we gracefully terminate or kill it.

7. **Smaller Tweaks**  
   - Renamed `get_send_message` to `create_message` in Control to better reflect it’s constructing something new.  
   - Replaced a `.format()` call with an f-string to keep the code style consistent.

Throughout these changes, I tried to test everything thoroughly. Some concurrency aspects are still tough to fully validate in a purely local environment (like race conditions that might only appear under big loads), but hopefully the approach is sound. If you prefer smaller bites, you can definitely pick the parts you want (like just the ConnectionSaver fix or the manage_old_workers refactor) and leave anything you’re unsure about.

Tests are green, ./run_demo.py is working.

Anyway, let me know what you think. I'd really like to learn more together :+1: 