### PR TITLE
Close connection on cleanup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -64,6 +64,7 @@ def clear_connection():
     Tests will do a lot of unthoughtful forking, and connections can not
     be shared accross processes.
     """
+    yield
     if connection_save._connection:
         connection_save._connection.close()
         connection_save._connection = None


### PR DESCRIPTION
I think this is what is wanted.

Fixes `/home/alancoding/venvs/awx/lib64/python3.12/site-packages/psycopg/_connection_base.py:146: ResourceWarning: connection <psycopg.Connection [IDLE] (host=localhost port=55777 user=dispatch database=dispatch_db) at 0x7efbef973710> was deleted while still open. Please use 'with' or '.close()' to close the connection`

I encountered the error on this PR https://github.com/ansible/dispatcherd/pull/129

Other things I tried that didn't work

```
@pytest.fixture(scope='module')
def pg_broker() -> Generator[Broker, None, None]:
    settings = DispatcherSettings(BASIC_CONFIG)
    publisher = get_publisher_from_settings(settings=settings)
    yield publisher
    publisher.close()


@pytest.fixture(scope='module')
def pg_control():
    settings = DispatcherSettings(BASIC_CONFIG)
    return get_control_from_settings(settings=settings)


def test_run_lambda_function(pg_dispatcher, pg_broker):
    pg_broker.publish_message(message='lambda: "This worked!"')
    message = pg_dispatcher.q_out.get(timeout=1)
    assert message == 'work_cleared'
```

Code change:
```
    publisher = get_publisher_from_settings(settings=settings)
    yield publisher
    publisher.close()
```
^^^ the publisher broker doesn't _own_ the connection so it won't close it, even though I added the explicit close.